### PR TITLE
Readme: update example to use equally oriented triangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ var boundary = require('simplicial-complex-boundary')
 
 var cells = [
   [0,1,2],
-  [1,2,3]
+  [2,1,3]
 ]
 
 console.log(boundary(cells))
@@ -18,7 +18,7 @@ console.log(boundary(cells))
 Output:
 
 ```
-[ [ 0, 1 ], [ 0, 2 ], [ 1, 3 ], [ 2, 3 ] ]
+[ [ 0, 1 ], [ 1, 3 ], [ 3, 2 ], [ 2, 0 ] ]
 ```
 
 # Install


### PR DESCRIPTION
This module doesn't support simplices with different orientations, but
the example was using them. It is updated with the cells used in a unit
test.

See mikolalysenko/simplicial-complex-boundary#2.
